### PR TITLE
Enhance cookie category management by selectivly rendering categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ The classNames are organized by component type:
 
 ## Cookie Categories
 
-The component manages three categories of cookies:
+The component supports managing consent for three predefined cookie categories:
 
 ```typescript
 interface CookieCategories {
@@ -551,6 +551,32 @@ interface CookieCategories {
   Advertising: boolean;
 }
 ```
+
+You can control which categories appear in the Manage Preferences UI by using the cookieCategories prop. This allows you to selectively hide or show specific categories based on your needs:
+
+```jsx
+<CookieManager
+  cookieCategories={{
+    Analytics: true, // Show Analytics category
+    Social: false, // Hide Social category
+    Advertising: true, // Show Advertising category
+  }}
+>
+  {children}
+</CookieManager>
+```
+
+By default, all categories are shown. When a category is hidden, its initial value is still respected as defined in the initialPreferences prop. The default preferences are:
+
+```typescript
+{
+  Analytics: false,
+  Social: false,
+  Advertising: false,
+}
+```
+
+This means even hidden categories will retain their configured initial values and can still be programmatically accessed.
 
 ## Hook API
 

--- a/src/components/ManageConsent.tsx
+++ b/src/components/ManageConsent.tsx
@@ -14,6 +14,7 @@ interface ManageConsentProps {
   onCancel?: () => void;
   initialPreferences?: CookieCategories;
   detailedConsent?: DetailedCookieConsent | null;
+  cookieCategories?: CookieCategories;
   classNames?: CookieConsenterClassNames;
 }
 
@@ -26,6 +27,11 @@ export const ManageConsent: React.FC<ManageConsentProps> = ({
     Analytics: false,
     Social: false,
     Advertising: false,
+  },
+  cookieCategories = {
+    Analytics: true,
+    Social: true,
+    Advertising: true,
   },
   detailedConsent,
   classNames,
@@ -177,55 +183,57 @@ export const ManageConsent: React.FC<ManageConsentProps> = ({
         </div>
 
         {/* Analytics Cookies */}
-        <div
-          className={
-            classNames?.manageCookieCategory
-              ? cn(classNames.manageCookieCategory)
-              : "flex items-start justify-between"
-          }
-        >
-          <div>
-            <h4
-              className={
-                classNames?.manageCookieCategoryTitle
-                  ? cn(classNames.manageCookieCategoryTitle)
-                  : cn(
-                      "text-xs font-medium text-left",
-                      theme === "light" ? "text-gray-900" : "text-white"
-                    )
-              }
-            >
-              {tFunction("manageAnalyticsTitle")}
-            </h4>
-            <p
-              className={
-                classNames?.manageCookieCategorySubtitle
-                  ? cn(classNames.manageCookieCategorySubtitle)
-                  : cn(
-                      "text-xs text-left",
-                      theme === "light" ? "text-gray-600" : "text-gray-400"
-                    )
-              }
-            >
-              {tFunction("manageAnalyticsSubtitle")}
-            </p>
-            {renderConsentStatus("Analytics")}
-          </div>
-          <label className="relative inline-flex items-center cursor-pointer">
-            <input
-              type="checkbox"
-              checked={consent.Analytics}
-              onChange={() => handleToggle("Analytics")}
-              className="sr-only peer"
-            />
-            <div
-              className={
-                classNames?.manageCookieToggle
-                  ? cn(
-                      classNames.manageCookieToggle,
-                      consent.Analytics && classNames.manageCookieToggleChecked
-                    )
-                  : cn(`w-11 h-6 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 
+        {cookieCategories.Analytics !== false && (
+          <div
+            className={
+              classNames?.manageCookieCategory
+                ? cn(classNames.manageCookieCategory)
+                : "flex items-start justify-between"
+            }
+          >
+            <div>
+              <h4
+                className={
+                  classNames?.manageCookieCategoryTitle
+                    ? cn(classNames.manageCookieCategoryTitle)
+                    : cn(
+                        "text-xs font-medium text-left",
+                        theme === "light" ? "text-gray-900" : "text-white"
+                      )
+                }
+              >
+                {tFunction("manageAnalyticsTitle")}
+              </h4>
+              <p
+                className={
+                  classNames?.manageCookieCategorySubtitle
+                    ? cn(classNames.manageCookieCategorySubtitle)
+                    : cn(
+                        "text-xs text-left",
+                        theme === "light" ? "text-gray-600" : "text-gray-400"
+                      )
+                }
+              >
+                {tFunction("manageAnalyticsSubtitle")}
+              </p>
+              {renderConsentStatus("Analytics")}
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={consent.Analytics}
+                onChange={() => handleToggle("Analytics")}
+                className="sr-only peer"
+              />
+              <div
+                className={
+                  classNames?.manageCookieToggle
+                    ? cn(
+                        classNames.manageCookieToggle,
+                        consent.Analytics &&
+                          classNames.manageCookieToggleChecked
+                      )
+                    : cn(`w-11 h-6 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 
                 ${
                   theme === "light"
                     ? "bg-gray-200 peer-checked:bg-blue-500"
@@ -234,61 +242,63 @@ export const ManageConsent: React.FC<ManageConsentProps> = ({
                 peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-0.5 
                 after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 
                 after:transition-all`)
-              }
-            ></div>
-          </label>
-        </div>
+                }
+              ></div>
+            </label>
+          </div>
+        )}
 
         {/* Social Cookies */}
-        <div
-          className={
-            classNames?.manageCookieCategory
-              ? cn(classNames.manageCookieCategory)
-              : "flex items-start justify-between"
-          }
-        >
-          <div>
-            <h4
-              className={
-                classNames?.manageCookieCategoryTitle
-                  ? cn(classNames.manageCookieCategoryTitle)
-                  : cn(
-                      "text-xs font-medium text-left",
-                      theme === "light" ? "text-gray-900" : "text-white"
-                    )
-              }
-            >
-              {tFunction("manageSocialTitle")}
-            </h4>
-            <p
-              className={
-                classNames?.manageCookieCategorySubtitle
-                  ? cn(classNames.manageCookieCategorySubtitle)
-                  : cn(
-                      "text-xs text-left",
-                      theme === "light" ? "text-gray-600" : "text-gray-400"
-                    )
-              }
-            >
-              {tFunction("manageSocialSubtitle")}
-            </p>
-            {renderConsentStatus("Social")}
-          </div>
-          <label className="relative inline-flex items-center cursor-pointer">
-            <input
-              type="checkbox"
-              checked={consent.Social}
-              onChange={() => handleToggle("Social")}
-              className="sr-only peer"
-            />
-            <div
-              className={
-                classNames?.manageCookieToggle
-                  ? cn(
-                      classNames.manageCookieToggle,
-                      consent.Social && classNames.manageCookieToggleChecked
-                    )
-                  : cn(`w-11 h-6 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 
+        {cookieCategories.Social !== false && (
+          <div
+            className={
+              classNames?.manageCookieCategory
+                ? cn(classNames.manageCookieCategory)
+                : "flex items-start justify-between"
+            }
+          >
+            <div>
+              <h4
+                className={
+                  classNames?.manageCookieCategoryTitle
+                    ? cn(classNames.manageCookieCategoryTitle)
+                    : cn(
+                        "text-xs font-medium text-left",
+                        theme === "light" ? "text-gray-900" : "text-white"
+                      )
+                }
+              >
+                {tFunction("manageSocialTitle")}
+              </h4>
+              <p
+                className={
+                  classNames?.manageCookieCategorySubtitle
+                    ? cn(classNames.manageCookieCategorySubtitle)
+                    : cn(
+                        "text-xs text-left",
+                        theme === "light" ? "text-gray-600" : "text-gray-400"
+                      )
+                }
+              >
+                {tFunction("manageSocialSubtitle")}
+              </p>
+              {renderConsentStatus("Social")}
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={consent.Social}
+                onChange={() => handleToggle("Social")}
+                className="sr-only peer"
+              />
+              <div
+                className={
+                  classNames?.manageCookieToggle
+                    ? cn(
+                        classNames.manageCookieToggle,
+                        consent.Social && classNames.manageCookieToggleChecked
+                      )
+                    : cn(`w-11 h-6 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 
                 ${
                   theme === "light"
                     ? "bg-gray-200 peer-checked:bg-blue-500"
@@ -297,62 +307,64 @@ export const ManageConsent: React.FC<ManageConsentProps> = ({
                 peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-0.5 
                 after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 
                 after:transition-all`)
-              }
-            ></div>
-          </label>
-        </div>
+                }
+              ></div>
+            </label>
+          </div>
+        )}
 
         {/* Advertising Cookies */}
-        <div
-          className={
-            classNames?.manageCookieCategory
-              ? cn(classNames.manageCookieCategory)
-              : "flex items-start justify-between"
-          }
-        >
-          <div>
-            <h4
-              className={
-                classNames?.manageCookieCategoryTitle
-                  ? cn(classNames.manageCookieCategoryTitle)
-                  : cn(
-                      "text-xs font-medium text-left",
-                      theme === "light" ? "text-gray-900" : "text-white"
-                    )
-              }
-            >
-              {tFunction("manageAdvertTitle")}
-            </h4>
-            <p
-              className={
-                classNames?.manageCookieCategorySubtitle
-                  ? cn(classNames.manageCookieCategorySubtitle)
-                  : cn(
-                      "text-xs text-left",
-                      theme === "light" ? "text-gray-600" : "text-gray-400"
-                    )
-              }
-            >
-              {tFunction("manageAdvertSubtitle")}
-            </p>
-            {renderConsentStatus("Advertising")}
-          </div>
-          <label className="relative inline-flex items-center cursor-pointer">
-            <input
-              type="checkbox"
-              checked={consent.Advertising}
-              onChange={() => handleToggle("Advertising")}
-              className="sr-only peer"
-            />
-            <div
-              className={
-                classNames?.manageCookieToggle
-                  ? cn(
-                      classNames.manageCookieToggle,
-                      consent.Advertising &&
-                        classNames.manageCookieToggleChecked
-                    )
-                  : cn(`w-11 h-6 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 
+        {cookieCategories.Advertising !== false && (
+          <div
+            className={
+              classNames?.manageCookieCategory
+                ? cn(classNames.manageCookieCategory)
+                : "flex items-start justify-between"
+            }
+          >
+            <div>
+              <h4
+                className={
+                  classNames?.manageCookieCategoryTitle
+                    ? cn(classNames.manageCookieCategoryTitle)
+                    : cn(
+                        "text-xs font-medium text-left",
+                        theme === "light" ? "text-gray-900" : "text-white"
+                      )
+                }
+              >
+                {tFunction("manageAdvertTitle")}
+              </h4>
+              <p
+                className={
+                  classNames?.manageCookieCategorySubtitle
+                    ? cn(classNames.manageCookieCategorySubtitle)
+                    : cn(
+                        "text-xs text-left",
+                        theme === "light" ? "text-gray-600" : "text-gray-400"
+                      )
+                }
+              >
+                {tFunction("manageAdvertSubtitle")}
+              </p>
+              {renderConsentStatus("Advertising")}
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={consent.Advertising}
+                onChange={() => handleToggle("Advertising")}
+                className="sr-only peer"
+              />
+              <div
+                className={
+                  classNames?.manageCookieToggle
+                    ? cn(
+                        classNames.manageCookieToggle,
+                        consent.Advertising &&
+                          classNames.manageCookieToggleChecked
+                      )
+                    : cn(`w-11 h-6 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 
                 ${
                   theme === "light"
                     ? "bg-gray-200 peer-checked:bg-blue-500"
@@ -361,10 +373,11 @@ export const ManageConsent: React.FC<ManageConsentProps> = ({
                 peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-0.5 
                 after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 
                 after:transition-all`)
-              }
-            ></div>
-          </label>
-        </div>
+                }
+              ></div>
+            </label>
+          </div>
+        )}
       </div>
 
       <div className="flex flex-col sm:flex-row gap-3 mt-2 sm:justify-end">

--- a/src/context/CookieConsentContext.tsx
+++ b/src/context/CookieConsentContext.tsx
@@ -146,6 +146,7 @@ export const CookieManager: React.FC<CookieManagerProps> = ({
   children,
   cookieKey = "cookie-consent",
   cookieKitId,
+  cookieCategories,
   userId,
   translations,
   translationI18NextPrefix,
@@ -162,8 +163,6 @@ export const CookieManager: React.FC<CookieManagerProps> = ({
   const [isVisible, setIsVisible] = useState(false);
   const [showManageConsent, setShowManageConsent] = useState(false);
   const [isFloatingButtonVisible, setIsFloatingButtonVisible] = useState(false);
-  const hasPostedSession = useRef(false);
-  const isGeneratingSession = useRef(false);
   const tFunction = useMemo(
     () => createTFunction(translations, translationI18NextPrefix),
     [translations, translationI18NextPrefix]
@@ -518,6 +517,7 @@ export const CookieManager: React.FC<CookieManagerProps> = ({
                         }
                       : undefined
                   }
+                  cookieCategories={cookieCategories}
                   detailedConsent={detailedConsent}
                   classNames={props.classNames}
                 />

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -234,6 +234,13 @@ export interface CookieConsenterProps {
   initialPreferences?: CookieCategories;
 
   /**
+   * Specifies which cookie categories should be displayed in the "Manage Preferences" view.
+   * This does not affect essential cookies, which are always shown.
+   * @default { Analytics: true, Social: true, Advertising: true }
+   */
+  cookieCategories?: CookieCategories;
+
+  /**
    * Detailed consent information including timestamps
    */
   detailedConsent?: DetailedCookieConsent | null;


### PR DESCRIPTION
This pull request introduces a new feature to allow selective display of cookie categories in the "Manage Preferences" UI. It adds a `cookieCategories` prop that enables developers to control which cookie categories are visible, while ensuring hidden categories retain their initial preferences. The implementation spans updates to documentation, type definitions, and component logic.

Example: 
```tsx
<CookieManager cookieCategories={{ Analytics: true, Social: false, Advertising: true }} />
```

Fixes #19 
