### PR TITLE
Expose openPreferencesModal method via hook

### DIFF
--- a/src/context/CookieConsentContext.tsx
+++ b/src/context/CookieConsentContext.tsx
@@ -72,6 +72,7 @@ interface CookieConsentContextValue {
   acceptCookies: () => void;
   declineCookies: () => void;
   updateDetailedConsent: (preferences: CookieCategories) => void;
+  openPreferencesModal: () => void;
 }
 
 const CookieManagerContext = createContext<CookieConsentContextValue | null>(
@@ -420,6 +421,18 @@ export const CookieManager: React.FC<CookieManagerProps> = ({
     setIsFloatingButtonVisible(false);
   };
 
+  const openPreferencesModal = () => {
+    if (detailedConsent) {
+      // If user has already made a consent decision, show the manage modal
+      setShowManageConsent(true);
+      setIsFloatingButtonVisible(false);
+      setIsVisible(false);
+    } else {
+      // If no consent decision has been made, show the initial consent banner
+      setIsVisible(true);
+    }
+  };
+
   const handleCancelManage = () => {
     setShowManageConsent(false);
     if (enableFloatingButton && detailedConsent) {
@@ -466,6 +479,7 @@ export const CookieManager: React.FC<CookieManagerProps> = ({
     acceptCookies,
     declineCookies,
     updateDetailedConsent,
+    openPreferencesModal,
   };
 
   return (


### PR DESCRIPTION
It would be nice to be able to open the preferences modal programatically. I saw there's an event listener on the window object, but I'd prefer not to go that route and just use a mechanism the hook exposes.

I made it a little smart, conditionally opening the banner or the preferences modal, depending on whether the user has already accepted the cookies or not, but it could be stupider than that, if you think that's better.

I can also remove the comments before merging.