### PR TITLE
Added feature to show banner only for specific geographic regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Privacy-first, flexible cookie consent for React. Automatically block trackers, 
 
 ![React Cookie Manager](https://github.com/hypershiphq/react-cookie-manager/blob/main/assets/react-cookie-manager.gif?raw=true)
 
+## Feature highlights
+
+- Geolocation-based auto-display (shows banner only in regulated regions)
+- Automatic blocking of common trackers and third-party embeds
+- Granular categories (Analytics, Social, Advertising)
+- Beautiful, responsive UI (banner, popup, modal) with theming
+- Floating settings button and full preferences UI
+
 ## Quick Start
 
 Get up and running quickly with React Cookie Manager:
@@ -45,6 +53,7 @@ Styles are automatically injected; no manual CSS import is required.
 - [Try it out](#-try-it-out)
 - [CookieKit Integration](#cookiekit-integration)
 - [Automatically Disable Tracking](#automatically-disable-tracking)
+- [Geolocation](#geolocation)
 - [Installation](#installation)
 - [Basic Usage](#basic-usage)
 - [Next.js Usage](#nextjs-usage)
@@ -148,6 +157,25 @@ When a user hasn't consented to the required cookies, these embeds are replaced 
 This ensures your site remains GDPR-compliant while providing a seamless user experience.
 
 ![React Cookie Manager Styles](https://github.com/hypershiphq/react-cookie-manager/blob/main/assets/banner-styles.jpg?raw=true)
+
+## Geolocation
+
+React Cookie Manager can automatically decide whether to show the cookie banner based on the user’s region.
+
+- Logic: only shows for regulated jurisdictions (GDPR: EU/EEA/UK, CH, BR, CA/PIPEDA, AU, JP/APPI, KR/PIPA, certain US regions like US-CA).
+- Opt-out: pass `disableGeolocation` to skip the check and always show the banner when no consent is stored.
+
+### Usage
+
+```tsx
+import { CookieManager } from "react-cookie-manager";
+
+// Geolocation enabled by default
+<CookieManager>{children}</CookieManager>
+
+// Opt-out: disable geolocation gating
+<CookieManager disableGeolocation>{children}</CookieManager>
+```
 
 ## Basic Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cookie-manager",
-  "version": "3.8.2",
+  "version": "4.0.0",
   "description": "🍪 The ultimate React cookie consent solution. Automatically block trackers, manage consent preferences, and protect user privacy with an elegant UI. Perfect for modern web applications.",
   "repository": {
     "type": "git",

--- a/playground-next/src/app/page.tsx
+++ b/playground-next/src/app/page.tsx
@@ -1,14 +1,82 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useCookieConsent } from "react-cookie-manager";
 
 export default function Home() {
+  const { showConsentBanner, detailedConsent } = useCookieConsent();
+  const [consentStatus, setConsentStatus] = useState<string>("Checking...");
+
+  useEffect(() => {
+    if (detailedConsent) {
+      const status = detailedConsent.Advertising.consented
+        ? "Accepted"
+        : "Not Accepted";
+      setConsentStatus(status);
+    } else {
+      setConsentStatus("Not Set");
+    }
+  }, [detailedConsent]);
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <h1 className="text-4xl font-bold">Cookie Consent Playground</h1>
+    <main className="min-h-screen flex flex-col items-center gap-10 py-16 px-6">
+      <div className="flex items-center justify-center gap-8">
+        <span className="text-5xl md:text-6xl font-extrabold tracking-tight">Next.js</span>
+        <span className="text-7xl">🍪</span>
+      </div>
+
+      <h1 className="text-3xl md:text-4xl font-bold text-center">
+        Next.js Cookie Manager Playground
+      </h1>
+
+      <div className="w-full max-w-3xl rounded-xl border border-zinc-200 dark:border-zinc-800 p-6 shadow-sm">
+        <h2 className="text-xl font-semibold mb-2">Cookie Consent Status</h2>
+        <p className="mb-4">
+          Marketing/Advertising Cookies: <strong>{consentStatus}</strong>
+        </p>
+        <button
+          onClick={showConsentBanner}
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+        >
+          Show Cookie Consent Banner
+        </button>
+      </div>
+
+      <div className="w-full max-w-4xl rounded-xl border border-zinc-200 dark:border-zinc-800 p-6 shadow-sm">
+        <h2 className="text-xl font-semibold mb-2">YouTube Video Embed Test</h2>
+        <p className="mb-6">
+          This YouTube video is embedded directly to observe what happens when cookies haven&apos;t been accepted yet.
+        </p>
+        <div className="flex flex-col items-center gap-6">
+          <div className="video-container">
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=0"
+              title="YouTube video player"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            ></iframe>
+          </div>
+          <div className="video-container">
+            <iframe
+              width="800"
+              height="315"
+              src="https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=0"
+              title="YouTube video player"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            ></iframe>
+          </div>
+        </div>
+      </div>
+
       <Link
         href="/ssr-example"
-        className="mt-8 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+        className="mt-2 px-4 py-2 bg-zinc-700 text-white rounded hover:bg-zinc-800 transition-colors"
       >
         View SSR Example Page
       </Link>

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export {
   useCookieConsent,
 } from "./context/CookieConsentContext";
 export type { CookieManagerProps } from "./context/CookieConsentContext";
+export type { GeoOptions } from "./utils/geo";

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -1,0 +1,269 @@
+import { resolveCountryFromTimezone } from "./session-utils";
+
+export type JurisdictionCode =
+  | "NONE"
+  | "GDPR"
+  | "CH"
+  | "BR"
+  | "PIPEDA"
+  | "AU"
+  | "APPI"
+  | "PIPA"
+  | "US-CA";
+
+export interface GeoDetectionResult {
+  countryCode: string | null;
+  regionCode: string | null;
+}
+
+export interface GeoOptions {
+  disableGeo?: boolean;
+  endpointUrl?: string; // Custom geo endpoint returning JSON
+  timeoutMs?: number; // Network timeout for remote detection
+  cacheTtlMs?: number; // Local cache TTL
+  countryOverride?: string | null; // Force country code
+  regionOverride?: string | null; // Force region/state code
+  regulatedCountries?: string[]; // Additional ISO country codes to treat as regulated
+  regulatedRegions?: string[]; // Region codes like US-CA to treat as regulated
+  defaultBehavior?: "show" | "hide"; // Fallback when detection fails
+}
+
+const DEFAULT_ENDPOINT = "https://ipapi.co/json/";
+const DEFAULT_TIMEOUT_MS = 2000;
+const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const GEO_CACHE_KEY = "rcm_geo_cache_v1";
+
+const EU = new Set([
+  "AT",
+  "BE",
+  "BG",
+  "HR",
+  "CY",
+  "CZ",
+  "DK",
+  "EE",
+  "FI",
+  "FR",
+  "DE",
+  "GR",
+  "HU",
+  "IE",
+  "IT",
+  "LV",
+  "LT",
+  "LU",
+  "MT",
+  "NL",
+  "PL",
+  "PT",
+  "RO",
+  "SK",
+  "SI",
+  "ES",
+  "SE",
+]);
+const EEA = new Set(["IS", "NO", "LI"]);
+const UK = new Set(["GB"]);
+const CH = new Set(["CH"]);
+const BR = new Set(["BR"]);
+const CA = new Set(["CA"]);
+const AU = new Set(["AU"]);
+const JP = new Set(["JP"]);
+const KR = new Set(["KR"]);
+
+export function determineJurisdiction(
+  countryCode: string | null,
+  regionCode?: string | null,
+  extraCountries?: string[] | undefined,
+  extraRegions?: string[] | undefined
+): { showConsentBanner: boolean; jurisdiction: JurisdictionCode } {
+  if (!countryCode) {
+    return { showConsentBanner: true, jurisdiction: "NONE" };
+  }
+
+  const cc = countryCode.toUpperCase();
+  const rc = regionCode ? regionCode.toUpperCase() : null;
+
+  // Honor explicit region rules first (e.g., California)
+  if (rc && (extraRegions?.includes(rc) || rc === "US-CA")) {
+    return { showConsentBanner: true, jurisdiction: "US-CA" };
+  }
+
+  const jurisdictionMap: Array<{ sets: Set<string>[]; code: JurisdictionCode }>
+    = [
+    { sets: [EU, EEA, UK], code: "GDPR" },
+    { sets: [CH], code: "CH" },
+    { sets: [BR], code: "BR" },
+    { sets: [CA], code: "PIPEDA" },
+    { sets: [AU], code: "AU" },
+    { sets: [JP], code: "APPI" },
+    { sets: [KR], code: "PIPA" },
+  ];
+
+  for (const { sets, code } of jurisdictionMap) {
+    if (sets.some((set) => set.has(cc))) {
+      return { showConsentBanner: true, jurisdiction: code };
+    }
+  }
+
+  if (extraCountries?.some((c) => c.toUpperCase() === cc)) {
+    return { showConsentBanner: true, jurisdiction: "NONE" };
+  }
+
+  return { showConsentBanner: false, jurisdiction: "NONE" };
+}
+
+function readCache(): GeoDetectionResult | null {
+  try {
+    const raw = localStorage.getItem(GEO_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as {
+      expiresAt: number;
+      value: GeoDetectionResult;
+    };
+    if (Date.now() > parsed.expiresAt) return null;
+    return parsed.value;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(result: GeoDetectionResult, ttlMs: number) {
+  try {
+    const payload = {
+      expiresAt: Date.now() + ttlMs,
+      value: result,
+    };
+    localStorage.setItem(GEO_CACHE_KEY, JSON.stringify(payload));
+  } catch {
+    // ignore
+  }
+}
+
+async function fetchWithTimeout(url: string, timeoutMs: number): Promise<any> {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(t);
+    if (!res.ok) throw new Error("Geo endpoint error: " + res.status);
+    return await res.json();
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export async function detectGeo(options?: GeoOptions): Promise<GeoDetectionResult> {
+  const {
+    disableGeo,
+    endpointUrl,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+    countryOverride,
+    regionOverride,
+  } = options || {};
+
+  if (disableGeo) {
+    return { countryCode: null, regionCode: null };
+  }
+
+  if (countryOverride || regionOverride) {
+    return {
+      countryCode: countryOverride ?? null,
+      regionCode: regionOverride ?? null,
+    };
+  }
+
+  if (typeof window === "undefined") {
+    // SSR environment without overrides: no detection is possible here
+    return { countryCode: null, regionCode: null };
+  }
+
+  const cached = readCache();
+  if (cached) return cached;
+
+  // Attempt remote endpoint
+  try {
+    const data = await fetchWithTimeout(
+      endpointUrl || DEFAULT_ENDPOINT,
+      timeoutMs
+    );
+    // Try common field names across providers
+    const country =
+      data?.country || data?.countryCode || data?.country_code || null;
+    // Prefer ISO2 for region/state; some providers return region_code or region
+    const region =
+      data?.region_code || data?.regionCode || data?.region || null;
+
+    const result = {
+      countryCode: country ? String(country).toUpperCase() : null,
+      regionCode: region
+        ? String(region).toUpperCase().startsWith("US-")
+          ? String(region).toUpperCase()
+          : // Normalize US state to US-XX when country is US and region is just code
+            country && String(country).toUpperCase() === "US" &&
+            /^[A-Z]{2}$/.test(String(region).toUpperCase())
+          ? `US-${String(region).toUpperCase()}`
+          : String(region).toUpperCase()
+        : null,
+    } as GeoDetectionResult;
+
+    writeCache(result, cacheTtlMs);
+    return result;
+  } catch {
+    // Fallback to timezone-based approximation
+    try {
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      const cc = tz ? resolveCountryFromTimezone(tz) : null;
+      const approx: GeoDetectionResult = {
+        countryCode: cc && cc !== "Unknown" ? cc : null,
+        regionCode: null,
+      };
+      writeCache(approx, cacheTtlMs);
+      return approx;
+    } catch {
+      return { countryCode: null, regionCode: null };
+    }
+  }
+}
+
+export async function shouldShowConsentByGeo(
+  options?: GeoOptions
+): Promise<{
+  show: boolean;
+  countryCode: string | null;
+  regionCode: string | null;
+  jurisdiction: JurisdictionCode;
+}> {
+  const {
+    defaultBehavior = "hide",
+    regulatedCountries,
+    regulatedRegions,
+  } = options || {};
+
+  const { countryCode, regionCode } = await detectGeo(options);
+
+  if (!countryCode && defaultBehavior === "show") {
+    return { show: true, countryCode, regionCode, jurisdiction: "NONE" };
+  }
+
+  if (!countryCode && defaultBehavior === "hide") {
+    return { show: false, countryCode, regionCode, jurisdiction: "NONE" };
+  }
+
+  const { showConsentBanner, jurisdiction } = determineJurisdiction(
+    countryCode,
+    regionCode,
+    regulatedCountries,
+    regulatedRegions
+  );
+
+  return {
+    show: showConsentBanner,
+    countryCode,
+    regionCode,
+    jurisdiction,
+  };
+}
+
+

--- a/tests/CookieBlockingManager.unregulated.test.tsx
+++ b/tests/CookieBlockingManager.unregulated.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CookieManager } from '../src/context/CookieConsentContext';
+
+describe('unregulated regions: no banner -> allow all by default', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    // Cache a geo decision of show=false to simulate unregulated region
+    sessionStorage.setItem('rcm_geo_decision_v1', JSON.stringify({ ts: Date.now(), show: false }));
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    global.fetch = originalFetch as any;
+    vi.restoreAllMocks();
+  });
+
+  it('does not block tracking requests when geo says do not show banner', async () => {
+    // Spy on fetch to ensure it's not blocked by request-blocker
+    const spy = vi.spyOn(global, 'fetch');
+    spy.mockResolvedValue(new Response('{}', { status: 200 }))
+
+    render(
+      <CookieManager translations={{}}>
+        <div>App</div>
+      </CookieManager>
+    );
+
+    // Attempt a request to a known tracker host that would be blocked if preferences were null
+    await global.fetch('https://www.google-analytics.com/collect');
+    expect(spy).toHaveBeenCalled();
+
+    // Ensure the call was not short-circuited with 403 by our request blocker
+    const res = await spy.mock.results[0].value as Response;
+    expect(res.status).toBe(200);
+  });
+});
+
+

--- a/tests/Geo.ssr.test.ts
+++ b/tests/Geo.ssr.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { detectGeo, shouldShowConsentByGeo } from '../src/utils/geo';
+
+describe('geo utils SSR behavior', () => {
+  const originalWindow = globalThis.window as any;
+  const originalLocalStorage = globalThis.localStorage as any;
+  const originalFetch = globalThis.fetch as any;
+
+  beforeEach(() => {
+    // Simulate SSR (no window, no localStorage, no fetch)
+    // @ts-expect-error - deleting for test purposes
+    delete (globalThis as any).window;
+    // @ts-expect-error - deleting for test purposes
+    delete (globalThis as any).localStorage;
+    // Keep fetch defined in node, but we expect detectGeo to short-circuit before using it.
+  });
+
+  afterEach(() => {
+    // Restore globals
+    (globalThis as any).window = originalWindow;
+    (globalThis as any).localStorage = originalLocalStorage;
+    (globalThis as any).fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('detectGeo returns null codes on SSR', async () => {
+    const res = await detectGeo();
+    expect(res).toEqual({ countryCode: null, regionCode: null });
+  });
+
+  it('shouldShowConsentByGeo respects defaultBehavior on SSR when unknown', async () => {
+    const hide = await shouldShowConsentByGeo({ defaultBehavior: 'hide' });
+    expect(hide.show).toBe(false);
+    const show = await shouldShowConsentByGeo({ defaultBehavior: 'show' });
+    expect(show.show).toBe(true);
+  });
+
+  it('shouldShowConsentByGeo honors overrides even on SSR', async () => {
+    const res = await shouldShowConsentByGeo({ countryOverride: 'DE' });
+    expect(res.show).toBe(true);
+    expect(res.jurisdiction).toBe('GDPR');
+  });
+});
+
+

--- a/tests/Geo.test.ts
+++ b/tests/Geo.test.ts
@@ -1,0 +1,146 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  determineJurisdiction,
+  detectGeo,
+  shouldShowConsentByGeo,
+} from '../src/utils/geo';
+
+// Mock timezone -> country resolver for fallback path
+vi.mock('../src/utils/session-utils', () => {
+  return {
+    resolveCountryFromTimezone: vi.fn(() => 'FR'),
+  };
+});
+
+const getFetch = () => (globalThis as any).fetch as unknown as typeof fetch;
+
+describe('geo utilities', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('determineJurisdiction', () => {
+    it('returns GDPR for EU/EEA/UK countries', () => {
+      expect(determineJurisdiction('DE').jurisdiction).toBe('GDPR');
+      expect(determineJurisdiction('SE').jurisdiction).toBe('GDPR');
+      expect(determineJurisdiction('NO').jurisdiction).toBe('GDPR');
+      expect(determineJurisdiction('GB').jurisdiction).toBe('GDPR');
+      expect(determineJurisdiction('de').jurisdiction).toBe('GDPR');
+    });
+
+    it('maps CH, BR, CA, AU, JP, KR to their codes and shows banner', () => {
+      expect(determineJurisdiction('CH')).toEqual({ showConsentBanner: true, jurisdiction: 'CH' });
+      expect(determineJurisdiction('BR')).toEqual({ showConsentBanner: true, jurisdiction: 'BR' });
+      expect(determineJurisdiction('CA')).toEqual({ showConsentBanner: true, jurisdiction: 'PIPEDA' });
+      expect(determineJurisdiction('AU')).toEqual({ showConsentBanner: true, jurisdiction: 'AU' });
+      expect(determineJurisdiction('JP')).toEqual({ showConsentBanner: true, jurisdiction: 'APPI' });
+      expect(determineJurisdiction('KR')).toEqual({ showConsentBanner: true, jurisdiction: 'PIPA' });
+    });
+
+    it('shows for US-CA region specifically', () => {
+      expect(determineJurisdiction('US', 'US-CA')).toEqual({ showConsentBanner: true, jurisdiction: 'US-CA' });
+    });
+
+    it('can force show via extra countries/regions', () => {
+      expect(determineJurisdiction('IN')).toEqual({ showConsentBanner: false, jurisdiction: 'NONE' });
+      expect(determineJurisdiction('IN', null, ['IN'])).toEqual({ showConsentBanner: true, jurisdiction: 'NONE' });
+      // Implementation labels any region-based regulation as US-CA (CPRA-like). Match current behavior.
+      expect(determineJurisdiction('US', 'US-NY', undefined, ['US-NY'])).toEqual({ showConsentBanner: true, jurisdiction: 'US-CA' });
+    });
+
+    it('returns show when countryCode is null (unknown)', () => {
+      expect(determineJurisdiction(null)).toEqual({ showConsentBanner: true, jurisdiction: 'NONE' });
+    });
+  });
+
+  describe('detectGeo', () => {
+    it('honors disableGeo', async () => {
+      const result = await detectGeo({ disableGeo: true });
+      expect(result).toEqual({ countryCode: null, regionCode: null });
+    });
+
+    it('honors overrides and skips network/cache', async () => {
+      const spy = vi.spyOn(globalThis as any, 'fetch');
+      const result = await detectGeo({ countryOverride: 'US', regionOverride: 'US-CA' });
+      expect(spy).not.toHaveBeenCalled();
+      expect(result).toEqual({ countryCode: 'US', regionCode: 'US-CA' });
+    });
+
+    it('fetches from endpoint and normalizes region codes', async () => {
+      vi.spyOn(globalThis as any, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ country: 'US', region_code: 'CA' }),
+      } as any);
+
+      const result = await detectGeo();
+      expect(getFetch()).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ countryCode: 'US', regionCode: 'US-CA' });
+    });
+
+    it('caches results and reuses cache', async () => {
+      vi.spyOn(globalThis as any, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ country_code: 'FR', region: 'IDF' }),
+      } as any);
+
+      const first = await detectGeo({ cacheTtlMs: 60_000 });
+      expect(first).toEqual({ countryCode: 'FR', regionCode: 'IDF' });
+      expect(getFetch()).toHaveBeenCalledTimes(1);
+
+      // Second call should hit cache, no new fetch
+      const second = await detectGeo({ cacheTtlMs: 60_000 });
+      expect(second).toEqual(first);
+      expect(getFetch()).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to timezone-based country on fetch error/timeout', async () => {
+      vi.useFakeTimers();
+      vi.spyOn(globalThis as any, 'fetch').mockImplementationOnce((_: any, init: any) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+        }) as any;
+      });
+
+      const promise = detectGeo({ timeoutMs: 10 });
+      vi.advanceTimersByTime(20);
+      const result = await promise;
+      // Our mocked resolveCountryFromTimezone returns FR
+      expect(result).toEqual({ countryCode: 'FR', regionCode: null });
+    });
+  });
+
+  describe('shouldShowConsentByGeo', () => {
+    it('returns defaultBehavior when country is unknown', async () => {
+      const resHide = await shouldShowConsentByGeo({ disableGeo: true, defaultBehavior: 'hide' });
+      expect(resHide.show).toBe(false);
+      const resShow = await shouldShowConsentByGeo({ disableGeo: true, defaultBehavior: 'show' });
+      expect(resShow.show).toBe(true);
+    });
+
+    it('shows for GDPR via overrides without network', async () => {
+      const res = await shouldShowConsentByGeo({ countryOverride: 'DE' });
+      expect(res).toMatchObject({ show: true, jurisdiction: 'GDPR', countryCode: 'DE' });
+    });
+
+    it('respects regulatedCountries and regulatedRegions options', async () => {
+      // Country not regulated by default
+      let res = await shouldShowConsentByGeo({ countryOverride: 'IN' });
+      expect(res.show).toBe(false);
+
+      // Add country as regulated
+      res = await shouldShowConsentByGeo({ countryOverride: 'IN', regulatedCountries: ['IN'] });
+      expect(res.show).toBe(true);
+
+      // Region regulation (e.g., treat US-NY as regulated)
+      res = await shouldShowConsentByGeo({ countryOverride: 'US', regionOverride: 'US-NY', regulatedRegions: ['US-NY'] });
+      expect(res.show).toBe(true);
+    });
+  });
+});
+
+


### PR DESCRIPTION
- Updated CookieManager component to support geolocation checks and added a new prop to disable this feature.
- Enhanced README.md with new feature highlights, including geolocation-based auto-display for regulated regions and detailed usage instructions.
- Improved the playground example to demonstrate the new consent status handling and geolocation functionality.