### PR TITLE
Fix setting initial preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cookie-manager",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "🍪 The ultimate React cookie consent solution. Automatically block trackers, manage consent preferences, and protect user privacy with an elegant UI. Perfect for modern web applications.",
   "repository": {
     "type": "git",

--- a/playground-next/src/components/Providers.tsx
+++ b/playground-next/src/components/Providers.tsx
@@ -14,6 +14,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         translations={i18n.t}
         displayType="popup"
         theme="light"
+        initialPreferences={{ Analytics: true, Social: true, Advertising: true }}
         onAccept={() => {
           console.log("accept");
         }}

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -32,7 +32,7 @@
       }
     },
     "..": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -53,6 +53,7 @@ createRoot(document.getElementById("root")!).render(
       theme="light"
       cookieKitId="67b322ffb47f4471855cda97"
       displayType="popup"
+      initialPreferences={{ Analytics: true, Social: true, Advertising: true }}
       enableFloatingButton={true}
       onManage={(preferences) => {
         if (preferences) {

--- a/src/components/ManageConsent.tsx
+++ b/src/components/ManageConsent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   CookieCategories,
   DetailedCookieConsent,
@@ -37,6 +37,11 @@ export const ManageConsent: React.FC<ManageConsentProps> = ({
   classNames,
 }) => {
   const [consent, setConsent] = useState<CookieCategories>(initialPreferences);
+
+  // Keep local state in sync if initialPreferences prop changes
+  useEffect(() => {
+    setConsent(initialPreferences);
+  }, [initialPreferences]);
 
   const handleToggle = (category: keyof CookieCategories) => {
     setConsent((prev) => ({

--- a/src/context/CookieConsentContext.tsx
+++ b/src/context/CookieConsentContext.tsx
@@ -218,6 +218,18 @@ export const CookieManager: React.FC<CookieManagerProps> = ({
     ? Object.values(detailedConsent).some((status) => status.consented)
     : null;
 
+  // Prefer existing consent. Otherwise use provided initialPreferences from props
+  const derivedInitialPreferences = useMemo(() => {
+    if (detailedConsent) {
+      return {
+        Analytics: detailedConsent.Analytics.consented,
+        Social: detailedConsent.Social.consented,
+        Advertising: detailedConsent.Advertising.consented,
+      };
+    }
+    return props.initialPreferences;
+  }, [detailedConsent, props.initialPreferences]);
+
   // Use the CookieBlockingManager
   const cookieBlockingManager = useRef<CookieBlockingManager | null>(null);
 
@@ -624,15 +636,7 @@ export const CookieManager: React.FC<CookieManagerProps> = ({
           onDecline={declineCookies}
           onManage={handleManage}
           detailedConsent={detailedConsent}
-          initialPreferences={
-            detailedConsent
-              ? {
-                  Analytics: detailedConsent.Analytics.consented,
-                  Social: detailedConsent.Social.consented,
-                  Advertising: detailedConsent.Advertising.consented,
-                }
-              : undefined
-          }
+          initialPreferences={derivedInitialPreferences}
         />
       )}
       {showManageConsent && typeof document !== "undefined" &&
@@ -652,15 +656,7 @@ export const CookieManager: React.FC<CookieManagerProps> = ({
                     theme={theme}
                     onSave={updateDetailedConsent}
                     onCancel={handleCancelManage}
-                    initialPreferences={
-                      detailedConsent
-                        ? {
-                            Analytics: detailedConsent.Analytics.consented,
-                            Social: detailedConsent.Social.consented,
-                            Advertising: detailedConsent.Advertising.consented,
-                          }
-                        : undefined
-                    }
+                    initialPreferences={derivedInitialPreferences}
                     cookieCategories={cookieCategories}
                     detailedConsent={detailedConsent}
                     classNames={props.classNames}

--- a/tests/CookieManager.initialPreferences.test.tsx
+++ b/tests/CookieManager.initialPreferences.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CookieManager } from '../src/context/CookieConsentContext';
+
+describe('CookieManager initialPreferences', () => {
+  test('Manage modal uses initialPreferences when no prior consent', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CookieManager
+        showManageButton
+        initialPreferences={{ Analytics: true, Social: true, Advertising: true }}
+      >
+        <div />
+      </CookieManager>
+    );
+
+    // Open Manage dialog from banner
+    const manageBtn = await screen.findByText('Manage Cookies');
+    await user.click(manageBtn);
+
+    // Wait for lazy-loaded ManageConsent content
+    await screen.findByText('Cookie Preferences');
+
+    // Find toggles by proximity to headings
+    const getToggleFor = (title: string) => {
+      const heading = screen.getByText(title);
+      const container = heading.closest('div')?.parentElement as HTMLElement;
+      return container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    };
+
+    expect(getToggleFor('Analytics').checked).toBe(true);
+    expect(getToggleFor('Social').checked).toBe(true);
+    expect(getToggleFor('Advertising').checked).toBe(true);
+  });
+});
+
+


### PR DESCRIPTION
- Added initialPreferences prop to manage consent preferences in Providers.
- Enhanced ManageConsent component to synchronize local state with initialPreferences changes.
- Refactored CookieManager to derive initial preferences from detailed consent or props.