### PR TITLE
Do not reopen the consent banner when manage is cancelled after consent

### DIFF
--- a/src/context/CookieConsentContext.tsx
+++ b/src/context/CookieConsentContext.tsx
@@ -514,9 +514,15 @@ export const CookieManager: React.FC<CookieManagerProps> = ({
 
   const handleCancelManage = () => {
     setShowManageConsent(false);
-    if (enableFloatingButton && detailedConsent) {
-      setIsFloatingButtonVisible(true);
+    if (detailedConsent) {
+      // User already made a consent decision, so cancelling manage should
+      // just close the modal, not re-open the initial consent banner.
+      if (enableFloatingButton) {
+        setIsFloatingButtonVisible(true);
+      }
     } else {
+      // No decision yet, so manage was opened from the first-run banner.
+      // Cancelling should bring the banner back so the user still has to choose.
       setIsVisible(true);
     }
   };

--- a/tests/CookieManager.context.test.tsx
+++ b/tests/CookieManager.context.test.tsx
@@ -14,6 +14,15 @@ const Consumer = () => {
 };
 
 describe('CookieManager context', () => {
+  beforeEach(() => {
+    // Reset cookies so each test starts from a clean consent state
+    document.cookie.split(';').forEach(c => {
+      const eqPos = c.indexOf('=');
+      const name = eqPos > -1 ? c.slice(0, eqPos) : c;
+      document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+    });
+  });
+
   test('openPreferencesModal shows manage modal when consent exists', async () => {
     const user = userEvent.setup();
     render(
@@ -33,6 +42,48 @@ describe('CookieManager context', () => {
 
     // Manage UI title should be visible
     expect(await screen.findByText('Cookie Preferences')).toBeInTheDocument();
+  });
+
+  test('cancelling manage does not reopen the consent banner when consent already exists', async () => {
+    const user = userEvent.setup();
+    render(
+      <CookieManager showManageButton>
+        <Consumer />
+      </CookieManager>
+    );
+
+    // Accept first to create consent
+    await user.click(await screen.findByText('Accept'));
+    await waitFor(() => expect(document.cookie).toMatch(/cookie-consent=/), { timeout: 1500 });
+
+    // Open the manage modal via the context, then cancel it
+    await user.click(screen.getByText('Open Prefs'));
+    expect(await screen.findByText('Cookie Preferences')).toBeInTheDocument();
+    await user.click(screen.getByText('Cancel'));
+
+    // The manage modal should close without bringing back the initial banner
+    await waitFor(() => {
+      expect(screen.queryByText('Cookie Preferences')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('We use cookies')).not.toBeInTheDocument();
+  });
+
+  test('cancelling manage reopens the consent banner when no consent decision exists yet', async () => {
+    const user = userEvent.setup();
+    render(
+      <CookieManager showManageButton>
+        <Consumer />
+      </CookieManager>
+    );
+
+    // No consent yet: the initial banner is showing. Open manage from it.
+    expect(await screen.findByText('We use cookies')).toBeInTheDocument();
+    await user.click(screen.getByText('Manage Cookies'));
+    expect(await screen.findByText('Cookie Preferences')).toBeInTheDocument();
+    await user.click(screen.getByText('Cancel'));
+
+    // The initial banner should come back so the user still has to choose.
+    expect(await screen.findByText('We use cookies')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
Fixes #82

`handleCancelManage` fell back to `setIsVisible(true)` whenever the floating button was disabled, even with a stored consent decision. A returning user who opened cookie settings and clicked Cancel was re-prompted with the initial banner.

## What changed

The cancel path now branches on whether a decision exists (`detailedConsent`) instead of on `enableFloatingButton`:

- With a stored decision, Cancel just closes the manage view. The floating button is shown again only when `enableFloatingButton` is on. The banner does not reopen.
- With no decision yet, manage was opened from the first-run banner, so Cancel brings the banner back and the user still has to choose.

## Tests

Two new tests in `tests/CookieManager.context.test.tsx`: cancelling with existing consent does not reopen the banner (this one fails on current main), and cancelling with no prior consent still does. Added a `beforeEach` cookie reset so each test starts clean. Full suite passes.
